### PR TITLE
bumped gui-diff version to 0.6.7; bumped app version to 1.0.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject print-foo "1.0.2"
+(defproject print-foo "1.0.3"
   :description "A set of useful print-debugging tools"
   :url "https://github.com/AlexBaranosky/print-foo"
   :license {:name "MIT License"
             :url "http://mit-license.org/"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [gui-diff "0.6.6"]]
+                 [gui-diff "0.6.7"]]
   :profiles {:dev {:dependencies [[org.clojars.runa/conjure "2.2.0"]]
                    :plugins [[jonase/eastwood "0.0.2"]]}}
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo/"


### PR DESCRIPTION
gui-diff 0.6.6 still depends on `ordered` instead of `flatland/ordered`. This is fixed in version `0.6.7`. 